### PR TITLE
Fix enumeration value 'VMI_OS_OSX' not explicitly handled in switch

### DIFF
--- a/src/libdrakvuf/drakvuf.c
+++ b/src/libdrakvuf/drakvuf.c
@@ -273,6 +273,7 @@ static bool _drakvuf_init_os(drakvuf_t drakvuf)
             break;
         case VMI_OS_UNKNOWN: /* fall-through */
         case VMI_OS_FREEBSD: /* fall-through */
+        case VMI_OS_OSX: /* fall-through */
         default:
             break;
     }


### PR DESCRIPTION
Fix enumeration value 'VMI_OS_OSX' not explicitly handled in switch

Simple fix, taken from: https://github.com/tklengyel/drakvuf/pull/1748/commits/f3aa585141bdabf82506eee93a1f3809bfe16393